### PR TITLE
Add compatibility methods in compatibility.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.0-alpha+2
+
+- Fix a generic type error
+- Added `compatibility.dart`, a temporary API to some users migrate
+
+Changes to `compatibility.dart` might not be considered in future semver
+updates, and it **highly suggested** you don't use these APIs for any new code.
+
 ## 1.0.0-alpha+1
 
 - Change `NgTextFixture.update` to have a single optional parameter

--- a/lib/compatibility.dart
+++ b/lib/compatibility.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Additional API to be used when migrating existing code to `angular_test`.
+///
+/// It is **highly recommended** not to use this and only stick to
+/// `angular_test.dart` for any new code or for new users of this package. APIs
+/// may change at _any time_ without adhering strictly to semver.
+
+export 'package:angular_test/src/frontend/fixture.dart'
+    show componentOfFixture, injectFromFixture;
+
+export 'package:angular_test/src/frontend/bed.dart'
+    show createDynamicFixture, createDynamicTestBed;

--- a/lib/src/frontend/fixture.dart
+++ b/lib/src/frontend/fixture.dart
@@ -9,6 +9,20 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/src/frontend/bed.dart';
 import 'package:angular_test/src/frontend/stabilizer.dart';
 
+/// Inject a service for [tokenOrType] from [fixture].
+///
+/// This is for compatibility reasons only and should not be used otherwise.
+/*=T*/ injectFromFixture/*<T>*/(NgTestFixture fixture, tokenOrType) {
+  return fixture._rootComponentRef.injector.get(tokenOrType);
+}
+
+/// Returns the component instance backing [fixture].
+///
+/// This is for compatibility reasons only and should not be used otherwise.
+/*=T*/ componentOfFixture/*<T>*/(NgTestFixture/*<T>*/ fixture) {
+  return fixture._rootComponentRef.instance;
+}
+
 class NgTestFixture<T> {
   final ApplicationRef _applicationRef;
   final ComponentRef _rootComponentRef;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_test
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular_testing
 description: Testing infrastructure for AngularDart
-version: 1.0.0-alpha+1
+version: 1.0.0-alpha+2
 
 environment:
   sdk: '>=1.20.0 <2.0.0'


### PR DESCRIPTION
Add a few _compatibility_ related methods (in a new entrypoint, `compatibility.dart`), that will be able to be used in order to consolidate internal test bed implementations to use `NgTestBed` as the backing implementation without breaking changes.

No API changes otherwise, but I'll bump the version anyway for syncing down.

Closes #5 
Closes #6 
Closes #7 

/cc @TedSander