### PR TITLE
Additional features for 3.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.0-beta+3
+
+- **BREAKING CHANGE**: Throws in bootstrapping if the root component does not
+  use default change detection. AngularDart does not support `OnPush` or other
+  change detection strategies on the root component.
+
+- Fixes a bug where the root was not removed from the DOM after disposed.
+
+- Added a missing dependency on `package:func`.
+
 ## 1.0.0-beta+2
 
 - Add support for setting a custom `PageLoader` factory:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Testing infrastructure and runner for [AngularDart][gh_angular_dart].
 
 [gh_angular_dart]: https://github.com/dart-lang/angular2
 
+It's **strongly recommended** to view the `test/` folder for examples and recommended patterns.
+
 ## Usage
 
 `angular_test` is both a framework for writing tests for AngularDart components _and_ a

--- a/lib/src/frontend/fixture.dart
+++ b/lib/src/frontend/fixture.dart
@@ -73,6 +73,7 @@ class NgTestFixture<T> {
   Future<Null> dispose() async {
     await update();
     _rootComponentRef.destroy();
+    (_rootComponentRef.location.nativeElement as Element).parent.remove();
     _applicationRef.dispose();
     activeTest = null;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,11 +14,16 @@ dependencies:
   angular2: '>=3.0.0-alpha+1 <4.0.0'
   ansicolor: '^0.0.9'
   args: '^0.13.7'
+  func: '^0.1.1'
   logging: '^0.11.3+1'
   matcher: '^0.12.0+2'
   pageloader: '^2.2.5'
   path: '^1.4.1'
   test: '^0.12.17'
+
+# Remove before publishing.
+dependency_overrides:
+  quiver:
 
 transformers:
   # Run the code generator on the entire package.

--- a/test/bootstrap_test.dart
+++ b/test/bootstrap_test.dart
@@ -12,28 +12,7 @@ import 'package:test/test.dart';
 
 @AngularEntrypoint()
 void main() {
-  test(
-    'should create a new component in the DOM',
-    NewComponentInDom._runTest,
-  );
-
-  test(
-    'should call a handler before initial load',
-    BeforeChangeDetection._runTest,
-  );
-
-  test(
-    'should include user-specified providers',
-    AddProviders._runTest,
-  );
-}
-
-@Component(
-  selector: 'test',
-  template: 'Hello World',
-)
-class NewComponentInDom {
-  static _runTest() async {
+  test('should create a new component in the DOM', () async {
     final host = new Element.div();
     final test = await bootstrapForTest(
       NewComponentInDom,
@@ -41,15 +20,9 @@ class NewComponentInDom {
     );
     expect(host.text, contains('Hello World'));
     test.destroy();
-  }
-}
+  });
 
-@Component(
-  selector: 'test',
-  template: 'Hello {{users.first}}!',
-)
-class BeforeChangeDetection {
-  static _runTest() async {
+  test('should call a handler before initial load', () async {
     final host = new Element.div();
     final test = await bootstrapForTest/*<BeforeChangeDetection>*/(
       BeforeChangeDetection,
@@ -58,18 +31,9 @@ class BeforeChangeDetection {
     );
     expect(host.text, contains('Hello Mati!'));
     test.destroy();
-  }
+  });
 
-  // This will fail with an NPE if not initialized before change detection.
-  final users = <String>[];
-}
-
-@Component(
-  selector: 'test',
-  template: '',
-)
-class AddProviders {
-  static _runTest() async {
+  test('should include user-specified providers', () async {
     final host = new Element.div();
     final test = await bootstrapForTest(
       AddProviders,
@@ -81,8 +45,36 @@ class AddProviders {
     AddProviders instance = test.instance;
     expect(instance._testService, isNotNull);
     test.destroy();
-  }
+  });
 
+  test('should throw if the root component is OnPush', () async {
+    expect(
+      bootstrapForTest(OnPushComponent, new DivElement()),
+      throwsUnsupportedError,
+    );
+  }, skip: 'See https://github.com/dart-lang/angular2/issues/329');
+}
+
+@Component(
+  selector: 'test',
+  template: 'Hello World',
+)
+class NewComponentInDom {}
+
+@Component(
+  selector: 'test',
+  template: 'Hello {{users.first}}!',
+)
+class BeforeChangeDetection {
+  // This will fail with an NPE if not initialized before change detection.
+  final users = <String>[];
+}
+
+@Component(
+  selector: 'test',
+  template: '',
+)
+class AddProviders {
   final TestService _testService;
 
   AddProviders(this._testService);
@@ -90,3 +82,17 @@ class AddProviders {
 
 @Injectable()
 class TestService {}
+
+@Component(
+  selector: 'test',
+  template: '{{"Hello World"}}',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+)
+class OnPushComponent {}
+
+@Component(
+  selector: 'test',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.Stateful,
+)
+class XXXComponent {}

--- a/test/frontend/bed_lifecycle_test.dart
+++ b/test/frontend/bed_lifecycle_test.dart
@@ -23,27 +23,67 @@ void main() {
 
   tearDown(disposeAnyRunningTest);
 
-  test('should render, update, and destroy a component', () {
-    return AngularLifecycle._runTest(docRoot, testRoot);
-  });
-}
-
-@Component(selector: 'test', template: '{{value}}')
-class AngularLifecycle {
-  static _runTest(Element docRoot, Element testRoot) async {
+  test('should render, update, and destroy a component', () async {
     // We are going to verify that the document root has a new node created (our
     // component), the node is updated (after change detection), and after
     // destroying the test the document root has been cleared.
-    final fixture = await new NgTestBed<AngularLifecycle>(
-      host: testRoot,
-    )
-        .create();
+    final testBed = new NgTestBed<AngularLifecycle>(host: testRoot);
+    final fixture = await testBed.create();
     expect(docRoot.text, isEmpty);
     await fixture.update((c) => c.value = 'New value');
     expect(docRoot.text, 'New value');
     await fixture.dispose();
+    print(docRoot.innerHtml);
     expect(docRoot.text, isEmpty);
+  });
+
+  test('should invoke ngOnChanges, then ngOnInit', () async {
+    final fixture = await new NgTestBed<NgOnChangesInitOrder>().create(
+      beforeChangeDetection: (root) => root.name = 'Hello',
+    );
+    await fixture.query<ChildWithLifeCycles>(
+      (el) => el.componentInstance is ChildWithLifeCycles,
+      (child) {
+        expect(child.events, ['OnChanges:name=Hello', 'OnInit']);
+      },
+    );
+  });
+}
+
+@Component(
+  selector: 'test',
+  template: '{{value}}',
+)
+class AngularLifecycle {
+  String value = '';
+}
+
+@Component(
+  selector: 'test',
+  directives: const [ChildWithLifeCycles],
+  template: '<child [name]="name"></child>',
+)
+class NgOnChangesInitOrder {
+  String name;
+}
+
+@Component(
+  selector: 'child',
+  template: '',
+)
+class ChildWithLifeCycles implements OnChanges, OnInit {
+  final events = <String>[];
+
+  @Input()
+  String name = '';
+
+  @override
+  void ngOnChanges(_) {
+    events.add('OnChanges:name=$name');
   }
 
-  String value = '';
+  @override
+  void ngOnInit() {
+    events.add('OnInit');
+  }
 }


### PR DESCRIPTION
Partial towards https://github.com/dart-lang/angular_test/issues/54 - we might need https://github.com/dart-lang/angular2/issues/329 resolved first, but added a test I can un-skip after that is investigated.

Closes https://github.com/dart-lang/angular_test/issues/53.

Added an example for https://github.com/dart-lang/angular_test/issues/44.

Also fixed some patterns in tests that weren't consistent across files so it is easier for our users to read the files and figure out proper use.