### PR TITLE
Rename angular2 -> angular.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Example use:
 @TestOn('browser')
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
@@ -47,10 +47,10 @@ You will need to also configure in `pubspec.yaml` to run code generation:
 ```yaml
 transformers:
   # Run the code generator on the entire package.
-  - angular2/transform/codegen
+  - angular/transform/codegen
 
   # Run the reflection remover on tests that have AoT enabled.
-  - angular2/transform/reflection_remover:
+  - angular/transform/reflection_remover:
       $include:
           - test/test_using_angular_test.dart
 

--- a/lib/src/bootstrap.dart
+++ b/lib/src/bootstrap.dart
@@ -5,12 +5,11 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular2/src/core/application_ref.dart';
-import 'package:angular2/src/core/change_detection/constants.dart';
-import 'package:angular2/src/core/linker/app_view_utils.dart';
-import 'package:angular2/angular2.dart';
-import 'package:angular2/platform/browser_static.dart';
-import 'package:angular2/src/core/linker/view_ref.dart';
+import 'package:angular/angular.dart';
+import 'package:angular/src/core/application_ref.dart';
+import 'package:angular/src/core/change_detection/constants.dart';
+import 'package:angular/src/core/linker/app_view_utils.dart';
+import 'package:angular/src/core/linker/view_ref.dart';
 
 /// Returns a future that completes with a new instantiated component.
 ///

--- a/lib/src/frontend/bed.dart
+++ b/lib/src/frontend/bed.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_test/src/bootstrap.dart';
 import 'package:angular_test/src/errors.dart';
 import 'package:angular_test/src/frontend/fixture.dart';

--- a/lib/src/frontend/fixture.dart
+++ b/lib/src/frontend/fixture.dart
@@ -5,10 +5,10 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
-import 'package:angular2/src/core/linker/view_ref.dart';
-import 'package:angular2/src/debug/debug_app_view.dart';
-import 'package:angular2/src/debug/debug_node.dart';
+import 'package:angular/angular.dart';
+import 'package:angular/src/core/linker/view_ref.dart';
+import 'package:angular/src/debug/debug_app_view.dart';
+import 'package:angular/src/debug/debug_node.dart';
 import 'package:angular_test/src/frontend/bed.dart';
 import 'package:angular_test/src/frontend/stabilizer.dart';
 import 'package:func/func.dart';

--- a/lib/src/frontend/stabilizer.dart
+++ b/lib/src/frontend/stabilizer.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/di.dart';
+import 'package:angular/di.dart';
 import 'package:angular_test/src/errors.dart';
 
 /// Abstraction around services that change the state of the DOM asynchronously.

--- a/lib/src/matchers/throws_in_angular.dart
+++ b/lib/src/matchers/throws_in_angular.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/src/facade/exceptions.dart';
+import 'package:angular/src/facade/exceptions.dart';
 import 'package:matcher/matcher.dart';
 import 'package:test/test.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ executables:
   angular_test:
 
 dependencies:
-  angular2: '>=3.0.0-alpha+1 <4.0.0'
+  angular: '4.0.0-dev'
   ansicolor: '^0.0.9'
   args: '>=0.13.7 <2.0.0'
   collection: '^1.14.0'
@@ -23,14 +23,13 @@ dependencies:
   path: '^1.4.1'
   stack_trace: ^1.7.0
   test: '^0.12.17'
-
 transformers:
   # Run the code generator on the entire package.
-  - angular2/transform/codegen
+  - angular/transform/codegen
 
   # Run the reflection remover just on tests that have AoT enabled.
   # TODO: Automate this, either via script or a naming convention.
-  - angular2/transform/reflection_remover:
+  - angular/transform/reflection_remover:
       $include:
           - test/frontend/bed_error_test.dart
           - test/frontend/bed_lifecycle_test.dart

--- a/test/bootstrap_test.dart
+++ b/test/bootstrap_test.dart
@@ -6,7 +6,7 @@
 @TestOn('browser')
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_test/src/bootstrap.dart';
 import 'package:test/test.dart';
 

--- a/test/frontend/bed_error_test.dart
+++ b/test/frontend/bed_error_test.dart
@@ -6,7 +6,7 @@
 @TestOn('browser')
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 

--- a/test/frontend/bed_lifecycle_test.dart
+++ b/test/frontend/bed_lifecycle_test.dart
@@ -6,7 +6,7 @@
 @TestOn('browser')
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 

--- a/test/frontend/pageloader_test.dart
+++ b/test/frontend/pageloader_test.dart
@@ -4,7 +4,7 @@
 
 @Tags(const ['aot'])
 @TestOn('browser')
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:pageloader/objects.dart';
 import 'package:test/test.dart';

--- a/test/frontend/query_test.dart
+++ b/test/frontend/query_test.dart
@@ -4,7 +4,7 @@
 
 @Tags(const ['aot'])
 @TestOn('browser')
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 

--- a/test/frontend/stabilizer_test.dart
+++ b/test/frontend/stabilizer_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/di.dart';
+import 'package:angular/di.dart';
 import 'package:angular_test/src/errors.dart';
 import 'package:angular_test/src/frontend/stabilizer.dart';
 import 'package:test/test.dart';

--- a/test/matchers/throws_in_angular_test.dart
+++ b/test/matchers/throws_in_angular_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/src/facade/exceptions.dart';
+import 'package:angular/src/facade/exceptions.dart';
 import 'package:angular_test/src/matchers.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
This is mostly to help with the mechanics of renaming angular itself. We won't publish this until angular 4.0 is ready.