### PR TITLE
Travis: no longer allow failures with dev release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ dart_task:
   # Let's be super aggressive, since it's 100% at the moment
   - dartanalyzer: . --fatal-hints --fatal-warnings --fatal-lints
 
-matrix:
-  allow_failures:
-    - dart: dev
-
 cache:
   directories:
     - $HOME/.pub-cache


### PR DESCRIPTION
These are now. Green. If they fail, we want the signal.